### PR TITLE
feat: Sets the enviroment for API Documentation with Swagger/OpenAPI

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 db.sqlite3
 # Ignore Python cache files and directories
 *.py[cod]
+# Ignore JetBrains IDE files
+.idea/

--- a/backend/.idea/iti_cafe.iml
+++ b/backend/.idea/iti_cafe.iml
@@ -17,6 +17,9 @@
     <orderEntry type="jdk" jdkName="Pipenv (iti_cafe)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="PackageRequirementsSettings">
+    <option name="requirementsPath" value="$MODULE_DIR$/requirements.txt" />
+  </component>
   <component name="TemplatesService">
     <option name="TEMPLATE_CONFIGURATION" value="Django" />
     <option name="TEMPLATE_FOLDERS">

--- a/backend/iti_cafe/settings.py
+++ b/backend/iti_cafe/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
    'corsheaders',
     'rest_framework_simplejwt.token_blacklist',
+    'drf_yasg',
 ]
 # CORS_ALLOWED_ORIGINS = [
 #     "http://localhost:3000",]  # React app

--- a/backend/iti_cafe/urls.py
+++ b/backend/iti_cafe/urls.py
@@ -16,10 +16,27 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
+schema_view = get_schema_view()
+open_api_info = openapi.Info(
+    title="ITI Cafe API",
+    default_version='v1',
+    description="ITI Cafe API",
+    # terms_of_service="https://www.google.com/policies/terms/",
+    contact=openapi.Contact(email="ahmedabougabal@live.com"),
+    license=openapi.License(name="BSD License"),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api-auth/',include('users.urls')),
     path('api/orders/', include('orders.urls')),
     path('api/menu/', include('menu.urls')),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+
 ]


### PR DESCRIPTION
use these imports in the top of your API Implementation to use the swagger decorator for documentation from drf_yasg.utils import swagger_auto_schema

from drf_yasg import openapi