### PR TITLE
Add sales_stats view to fetch sales statistics

### DIFF
--- a/backend/orders/views.py
+++ b/backend/orders/views.py
@@ -8,7 +8,8 @@ from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 from rest_framework.views import APIView
 
-from .models import Order
+from users.models import User
+from .models import Order, OrderItem
 from .permissions import IsAuthenticatedAndHasBranch, CanCreateOrder
 from .serializers import OrderSerializer, OrderCreateSerializer, OrderUpdateSerializer
 from drf_yasg.utils import swagger_auto_schema
@@ -21,6 +22,11 @@ from utils.email_utils import send_order_notification
 from django.core.mail import send_mail
 from django.conf import settings
 import json
+
+from django.db.models import Count, Sum, Avg
+from django.utils import timezone
+from datetime import timedelta
+
 
 # Initialize logger
 logger = logging.getLogger(__name__)
@@ -439,6 +445,56 @@ class OrderViewSet(viewsets.ModelViewSet):
                 return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         else:
             return Response({'error': 'Invalid request method'}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['get'])
+    def sales_stats(self, request):
+        try:
+            # These are the most bought items
+            most_bought = OrderItem.objects.values('item__name').annotate(
+                total_quantity=Sum('quantity')
+            ).order_by('-total_quantity')[:5]
+
+            # Monitor the busy times like that in Google Maps
+            orders = Order.objects.all()
+            busy_times = {
+                'Monday': [0] * 24,
+                'Tuesday': [0] * 24,
+                'Wednesday': [0] * 24,
+                'Thursday': [0] * 24,
+                'Friday': [0] * 24,
+                'Saturday': [0] * 24,
+                'Sunday': [0] * 24,
+            }
+            for order in orders:
+                day = order.created_at.strftime('%A')
+                hour = order.created_at.hour
+                busy_times[day][hour] += 1
+
+            # This is a simple calculation for summing all sales for the last 30 days
+            thirty_days_ago = timezone.now() - timedelta(days=30)
+            total_sales = Order.objects.filter(created_at__gte=thirty_days_ago).aggregate(
+                total=Sum('total_price')
+            )['total']
+
+            # Average order value
+            avg_order_value = Order.objects.aggregate(avg=Avg('total_price'))['avg']
+
+            # Top customers >3
+            top_customers = User.objects.annotate(
+                total_spent=Sum('order__total_price')
+            ).order_by('-total_spent')[:5].values('email', 'total_spent')
+
+            return Response({
+                'most_bought': most_bought,
+                'busy_times': busy_times,
+                'total_sales': total_sales,
+                'avg_order_value': avg_order_value,
+                'top_customers': top_customers,
+            })
+        except Exception as e:
+            print(f"Error in sales_stats: {str(e)}")
+            return Response({'error': str(e)}, status=500)
+
                 
 
     


### PR DESCRIPTION
- Implemented a new view function 'sales_stats' to fetch various sales statistics.
- Calculated the most bought items by aggregating order items and summing their quantities.
- Monitored busy times by counting orders per hour for each day of the week.
- Calculated total sales for the last 30 days by filtering orders and summing their total prices.
- Calculated the average order value by aggregating all orders.
- Identified the top customers by summing their total spent on orders and ordering by total spent.
- Returned the statistics as a JSON response or an error message if an exception occurs.


![image](https://github.com/user-attachments/assets/846ea536-da3e-445d-85d2-01ac39caa8dc)
