### PR TITLE
Add new API endpoint for sales statistics

### DIFF
--- a/backend/orders/urls.py
+++ b/backend/orders/urls.py
@@ -20,4 +20,5 @@ urlpatterns = [
     path('active-orders/', OrderViewSet.as_view({'get': 'active_orders'}), name='active-orders'),
     path('admin-active-orders/', OrderViewSet.as_view({'get': 'admin_active_orders'}), name='admin-active-orders'),
     path('notify-user/', OrderViewSet.as_view({'post': 'notifyUser'}),name='notify-user'),
+    path('sales-stats/', OrderViewSet.as_view({'get': 'sales_stats'}), name='sales-stats'),
 ]


### PR DESCRIPTION
- Added a new URL pattern for the 'sales_stats' view.
- Defined the endpoint as 'sales-stats/' and mapped it to the 'sales_stats' method in the OrderViewSet.
- This endpoint allows GET requests to fetch sales statistics.

![image](https://github.com/user-attachments/assets/6a9cd45d-1afc-4712-b7d2-95cc38b74cb0)
