### PR TITLE
Feat&Fix: fixed to display active orders of the user even if it is co…

### DIFF
--- a/backend/iti_cafe/settings.py
+++ b/backend/iti_cafe/settings.py
@@ -267,8 +267,10 @@ AUTH_USER_MODEL = 'users.User'
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"
 EMAIL_PORT=587
-EMAIL_HOST_USER="mahmoudwafi33@gmail.com"
-EMAIL_HOST_PASSWORD="egjv ffdo kaxm pest"
+EMAIL_HOST_USER="itifoods.newcapital@gmail.com"
+EMAIL_HOST_PASSWORD="sfkw hogm ozkm fgaf"
+# EMAIL_HOST_USER="mahmoudwafi33@gmail.com"
+# EMAIL_HOST_PASSWORD="egjv ffdo kaxm pest"
 EMAIL_USE_TLS=True
 DEFAULT_FROM_EMAIL="iticafe@gmail.com"
 

--- a/client/src/pages/Order/ActiveOrder.tsx
+++ b/client/src/pages/Order/ActiveOrder.tsx
@@ -51,6 +51,9 @@ const ActiveOrders: React.FC = () => {
                     <strong>Status:</strong> {order.status}
                   </Card.Text>
                   <Card.Text>
+                    <strong>Payment Status:</strong> {order.payment_status === 'paid' ? 'Paid' : 'Unpaid'}
+                  </Card.Text>
+                  <Card.Text>
                     <strong>Branch:</strong> {order.branch_name}
                   </Card.Text>
                   <Card.Text>


### PR DESCRIPTION
…mpleted as if it is an orders-history for the user and displays the payment status

changed the host_email whose responsible for sending clients email notifications upon orders' status as per orders cycle logic


![image](https://github.com/user-attachments/assets/3bb8508b-2420-407e-a111-83de4d079f3b)
